### PR TITLE
Allow users to select a Custom alarm audio file.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@
 *QRAlarm* is an Android alarm clock application that does not only wake You up, but also makes You get up to disable the alarm by scanning the QR Code.
 
 ## Screenshots
-<p>
-	<img src="./screenshots/HomeScreen.jpg" width="196" height="416"/>
-	<img src="./screenshots/SettingsScreen.jpg" width="196" height="416"/>
-	<img src="./screenshots/ScannerScreen.jpg" width="196" height="416"/>
-	<img src="./screenshots/GuideScreen.jpg" width="196" height="416"/>
-</p>
+<img src="./screenshots/HomeScreen.jpg" width="196" height="416"/>
+<img src="./screenshots/SettingsScreen.jpg" width="196" height="416"/>
+<img src="./screenshots/ScannerScreen.jpg" width="196" height="416"/>
+<img src="./screenshots/GuideScreen.jpg" width="196" height="416"/>
 
 ## Setup
 * Download [qralarm-android-signed.apk](https://github.com/sweakpl/qralarm-android/releases),

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 *QRAlarm* is an Android alarm clock application that does not only wake You up, but also makes You get up to disable the alarm by scanning the QR Code.
 
 ## Screenshots
-<img src="./screenshots/HomeScreen.jpg" width="196" height="416"/>
-<img src="./screenshots/SettingsScreen.jpg" width="196" height="416"/>
-<img src="./screenshots/ScannerScreen.jpg" width="196" height="416"/>
-<img src="./screenshots/GuideScreen.jpg" width="196" height="416"/>
+<p>
+	<img src="./screenshots/HomeScreen.jpg" width="196" height="416"/>
+	<img src="./screenshots/SettingsScreen.jpg" width="196" height="416"/>
+	<img src="./screenshots/ScannerScreen.jpg" width="196" height="416"/>
+	<img src="./screenshots/GuideScreen.jpg" width="196" height="416"/>
+</p>
 
 ## Setup
 * Download [qralarm-android-signed.apk](https://github.com/sweakpl/qralarm-android/releases),

--- a/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmService.kt
+++ b/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmService.kt
@@ -173,14 +173,17 @@ class QRAlarmService : Service() {
             dataStoreManager.getInt(DataStoreManager.ALARM_SOUND).first()
         }
 
-        return AlarmSound.fromInt(alarmSoundOrdinal).let {
-                Uri.parse(
-                    "android.resource://"
-                            + packageName
-                            + "/"
-                            + (it?.resourceId ?: AlarmSound.GENTLE_GUITAR.resourceId)
-                )
+        val selection = AlarmSound.fromInt(alarmSoundOrdinal) ?: AlarmSound.GENTLE_GUITAR
+        val uri = if (selection == AlarmSound.USER_FILE) {
+            val customFile = runBlocking {
+                dataStoreManager.getString(DataStoreManager.USER_ALARM_SOUND_URI).first()
+            }
+            Uri.parse(customFile)
+        } else {
+            Uri.parse("android.resource://" + packageName + "/" + selection.resourceId)
         }
+
+        return uri
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmService.kt
+++ b/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmService.kt
@@ -168,6 +168,7 @@ class QRAlarmService : Service() {
         }
     }
 
+    // WARNING: this code is duplicated in SettingsViewModel. I guess because OOP is dumb. I don't care enough to fix it
     private fun getPreferredAlarmSoundUri(): Uri {
         val alarmSoundOrdinal = runBlocking {
             dataStoreManager.getInt(DataStoreManager.ALARM_SOUND).first()

--- a/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmService.kt
+++ b/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmService.kt
@@ -181,7 +181,7 @@ class QRAlarmService : Service() {
             }
             Uri.parse(customFile)
         } else {
-            Uri.parse("android.resource://" + packageName + "/" + selection.resourceId)
+            Uri.parse("android.resource://$packageName/${selection.resourceId}")
         }
 
         return uri

--- a/app/src/main/java/com/sweak/qralarm/data/DataStoreManager.kt
+++ b/app/src/main/java/com/sweak/qralarm/data/DataStoreManager.kt
@@ -68,6 +68,7 @@ class DataStoreManager(private val context: Context) {
         val SNOOZE_AVAILABLE_COUNT = intPreferencesKey("snoozeAvailableCount")
         val SNOOZE_DURATION_MINUTES = intPreferencesKey("snoozeDurationMinutes")
         val ALARM_SOUND = intPreferencesKey("alarmSound")
+        val USER_ALARM_SOUND_URI = stringPreferencesKey("userAlarmSound")
         val DISMISS_ALARM_CODE = stringPreferencesKey("dismissAlarmCode")
     }
 }

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
@@ -75,7 +75,7 @@ fun SettingsScreen(
             settingsViewModel.updateCustomAlarmURI(localURI.toString())
             uiState.value = uiState.value.copy(customAlarmURI = localURI.toString())
         } else {
-            Toast.makeText(context, "Failed to select that file, falling back to default", Toast.LENGTH_LONG)
+            Toast.makeText(context, "Failed to select that file, falling back to default", Toast.LENGTH_LONG).show()
             settingsViewModel.updateAlarmSoundSelection(0)
             uiState.value = uiState.value.copy(selectedAlarmSoundIndex = 0)
         }

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
@@ -407,16 +407,9 @@ fun SettingsScreen(
 
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                text = uiState.value.customAlarmURI,
+                text = if (uiState.value.selectedAlarmSoundIndex != AVAILABLE_ALARM_SOUNDS.indexOf(AlarmSound.USER_FILE)) {""} else {"Custom alarm is selected (" + uiState.value.customAlarmURI + "). Warning: test playing it above to make sure it is valid. The app may crash, this is not a completely tested feature"},
                 style = MaterialTheme.typography.body1
             )
-            Spacer(modifier = Modifier.height(MaterialTheme.space.large))
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = uiState.value.selectedAlarmSoundIndex.toString(),
-                style = MaterialTheme.typography.body1
-            )
-            Spacer(modifier = Modifier.height(MaterialTheme.space.large))
         }
     }
 

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
@@ -75,6 +75,7 @@ fun SettingsScreen(
             settingsViewModel.updateCustomAlarmURI(localURI.toString())
             uiState.value = uiState.value.copy(customAlarmURI = localURI.toString())
         } else {
+            Toast.makeText(context, "Failed to select that file, falling back to default", Toast.LENGTH_LONG)
             settingsViewModel.updateAlarmSoundSelection(0)
             uiState.value = uiState.value.copy(selectedAlarmSoundIndex = 0)
         }
@@ -419,7 +420,7 @@ fun SettingsScreen(
 
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                text = if (uiState.value.selectedAlarmSoundIndex != AVAILABLE_ALARM_SOUNDS.indexOf(AlarmSound.USER_FILE)) {""} else {"Custom alarm is selected (" + uiState.value.customAlarmURI + "). Warning: test playing it above to make sure it is valid. The app may crash, this is not a completely tested feature"},
+                text = if (uiState.value.selectedAlarmSoundIndex != AVAILABLE_ALARM_SOUNDS.indexOf(AlarmSound.USER_FILE)) {""} else {"Custom alarm is selected. Warning: test playing it above to make sure it will work. The app may crash, this is not a well-tested feature"},
                 style = MaterialTheme.typography.body1
             )
         }

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
@@ -3,10 +3,7 @@ package com.sweak.qralarm.ui.screens.settings
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
-import android.provider.MediaStore
 import android.provider.Settings
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -188,33 +185,17 @@ fun SettingsScreen(
                             uiState.value = uiState.value.copy(alarmSoundsDropdownMenuExpanded = false)
                         },
                         onMenuItemClick = {
-                            index -> settingsViewModel.updateAlarmSoundSelection(index)
+                            index ->
+                            settingsViewModel.updateAlarmSoundSelection(index)
                             uiState.value = uiState.value.copy(alarmSoundsDropdownMenuExpanded = false)
 
                             val newSelectedAlarmSound = AVAILABLE_ALARM_SOUNDS[index]
                             if (newSelectedAlarmSound == AlarmSound.USER_FILE) {
-//                                val intent = Intent()
-//                                    .setAction(Intent.ACTION_GET_CONTENT)
-//                                    .putExtra(Intent.EXTRA_LOCAL_ONLY, true)
-//                                soundLauncherPicker.launch(intent)
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                                    context.contentResolver.query(
-                                        MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
-                                        null,
-                                        null,
-                                        null,
-                                    )?.use { cursor ->
-                                        while (cursor.moveToNext()) {
-                                            // Use an ID column from the projection to get // a URI representing the media item itself.
-                                            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID)
-                                            val uri = ???
-                                            settingsViewModel.updateCustomAlarmURI(uri)
-                                            uiState.value = uiState.value.copy(customAlarmURI = uri.toString() ?: "No custom URL")
-                                        }
-                                    }
-                                } else {
-                                    Toast.makeText(context, "Custom Files are only supported on Android O and up", 0).show()
-                                }
+                                val intent = Intent()
+                                    .setAction(Intent.ACTION_GET_CONTENT)
+                                    .setType("audio/*")
+                                    .putExtra(Intent.EXTRA_LOCAL_ONLY, true)
+                                soundLauncherPicker.launch(intent)
                             }
                         }
                     )

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
@@ -410,7 +410,12 @@ fun SettingsScreen(
                 text = uiState.value.customAlarmURI,
                 style = MaterialTheme.typography.body1
             )
-
+            Spacer(modifier = Modifier.height(MaterialTheme.space.large))
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = uiState.value.selectedAlarmSoundIndex.toString(),
+                style = MaterialTheme.typography.body1
+            )
             Spacer(modifier = Modifier.height(MaterialTheme.space.large))
         }
     }

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -46,7 +47,6 @@ import com.sweak.qralarm.util.AlarmSound
 import com.sweak.qralarm.util.SCAN_MODE_SET_CUSTOM_CODE
 import com.sweak.qralarm.util.Screen
 
-
 @ExperimentalPermissionsApi
 @Composable
 fun SettingsScreen(
@@ -66,8 +66,18 @@ fun SettingsScreen(
 
     val soundLauncherPicker = rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) {
         result ->
-        settingsViewModel.updateCustomAlarmURI(result.data?.data)
-        uiState.value = uiState.value.copy(customAlarmURI = result.data?.data?.toString() ?: "No custom URL")
+        var localURI: Uri? = null
+        if (result.data != null && result.data!!.data != null && result.data!!.data!!.path != null) {
+            localURI = duplicateURIContentToLocalStorage(result.data!!.data!!, context)
+        }
+        if (localURI != null) {
+            Toast.makeText(context, "Path is: ${localURI.path}", Toast.LENGTH_LONG).show()
+            settingsViewModel.updateCustomAlarmURI(localURI.toString())
+            uiState.value = uiState.value.copy(customAlarmURI = localURI.toString())
+        } else {
+            settingsViewModel.updateAlarmSoundSelection(0)
+            uiState.value = uiState.value.copy(selectedAlarmSoundIndex = 0)
+        }
     }
 
     DisposableEffect(lifecycleOwner) {

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsScreen.kt
@@ -207,9 +207,9 @@ fun SettingsScreen(
                                         while (cursor.moveToNext()) {
                                             // Use an ID column from the projection to get // a URI representing the media item itself.
                                             val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID)
-
-                                            settingsViewModel.updateCustomAlarmURI(result.data?.data)
-                                            uiState.value = uiState.value.copy(customAlarmURI = result.data?.data?.toString() ?: "No custom URL")
+                                            val uri = ???
+                                            settingsViewModel.updateCustomAlarmURI(uri)
+                                            uiState.value = uiState.value.copy(customAlarmURI = uri.toString() ?: "No custom URL")
                                         }
                                     }
                                 } else {

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsUiState.kt
@@ -20,5 +20,6 @@ data class SettingsUiState(
     val dismissAlarmCode: String,
     val showCameraPermissionDialog: Boolean = false,
     val showCameraPermissionRevokedDialog: Boolean = false,
-    val showDismissCodeAddedDialog: Boolean = false
+    val showDismissCodeAddedDialog: Boolean = false,
+    val customAlarmURI: String,
 )

--- a/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/sweak/qralarm/ui/screens/settings/SettingsViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.runBlocking
 import java.io.IOException
 import javax.inject.Inject
 
+
 @ExperimentalPermissionsApi
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
@@ -52,7 +53,8 @@ class SettingsViewModel @Inject constructor(
                     selectedSnoozeMaxCountIndex = AVAILABLE_SNOOZE_MAX_COUNTS.indexOf(
                         it.getInt(DataStoreManager.SNOOZE_MAX_COUNT).first()
                     ),
-                    dismissAlarmCode = it.getString(DataStoreManager.DISMISS_ALARM_CODE).first()
+                    dismissAlarmCode = it.getString(DataStoreManager.DISMISS_ALARM_CODE).first(),
+                    customAlarmURI = it.getString(DataStoreManager.USER_ALARM_SOUND_URI).first(),
                 )
             )
         }
@@ -261,5 +263,20 @@ class SettingsViewModel @Inject constructor(
         }
 
         settingsUiState.value = settingsUiState.value.copy(alarmPreviewPlaying = false)
+    }
+
+    fun updateCustomAlarmURI(uri: Uri?) {
+        if (uri != null) {
+            viewModelScope.launch {
+                dataStoreManager.putString(DataStoreManager.USER_ALARM_SOUND_URI, uri.toString())
+            }
+        } else {
+            viewModelScope.launch {
+                dataStoreManager.putInt(
+                    DataStoreManager.ALARM_SOUND,
+                    AlarmSound.GENTLE_GUITAR.ordinal
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/sweak/qralarm/util/Constants.kt
+++ b/app/src/main/java/com/sweak/qralarm/util/Constants.kt
@@ -19,7 +19,8 @@ enum class Meridiem {
 enum class AlarmSound(@RawRes val resourceId: Int, @StringRes val nameResourceId: Int) {
     GENTLE_GUITAR(R.raw.gentle_guitar, R.string.gentle_guitar),
     ALARM_CLOCK(R.raw.alarm_clock, R.string.alarm_clock),
-    AIR_HORN(R.raw.air_horn, R.string.air_horn);
+    AIR_HORN(R.raw.air_horn, R.string.air_horn),
+    USER_FILE(R.raw.gentle_guitar, R.string.user_alarm_file);
 
     companion object {
         fun fromInt(ordinal: Int) = values().firstOrNull { it.ordinal == ordinal }
@@ -30,6 +31,7 @@ val AVAILABLE_ALARM_SOUNDS = listOf(
     AlarmSound.GENTLE_GUITAR,
     AlarmSound.ALARM_CLOCK,
     AlarmSound.AIR_HORN,
+    AlarmSound.USER_FILE,
 )
 
 const val SNOOZE_DURATION_10_MINUTES = 10

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="gentle_guitar">Gentle guitar</string>
     <string name="alarm_clock">Alarm clock</string>
     <string name="air_horn">Air horn</string>
+    <string name="user_alarm_file">Custom File</string>
     <string name="save_default_qrcode">Download default QR Code</string>
     <string name="storage_permission_required_title">Storage permission required</string>
     <string name="storage_permission_required_message">QRAlarm needs access to Your phone’s storage in order to download a default QR Code that after being scanned will turn off alarms.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jan 02 13:37:44 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
As noted by the app now when you choose a custom file as your alarm sound, this can cause a crash when it attempts to play audio if the user picks the wrong thing, specifically if they try to use a playlist file (`.m3u`) as their custom file. You can probably detect this crash right as they pick the file rather when it is attempted to be played but I don't care to try to. Or figure out the mime type and try to exclude it that way - but I have been very frustrated by many apps that expect all audio files to be `mp3`s and would rather allow the user to figure it out than restrict them artificially.

There is also a crash which I'm not exactly sure how to reproduce which happened when I selected the same file multiple times in a row to be the new alarm. But it doesn't always happen, and once it works once it shouldn't break as it was related to saving the file I think.

Personally, I would still merge this because it is still a very good feature to have, people who use F-droid are probably okay with some small amount of jank in order to get (imo critical) features implemented faster, but if you want to not merge I don't care I wrote this for me. I probably also won't spend too much extra time trying to fix it if you decide this isn't good and won't fix it yourself.

Works by duplicating a file to local app storage, I didn't want to have to do that but it seems android's security model also prevents me from knowing any file paths even with storage permissions when using content API and I don't care to spend too much more time fighting with Android's weird APIs.

Only tested on android 13 so far. I'm not sure what would happen on an older version. I think pre-11 is when they changed some file APIs significantly.