### PR TITLE
Add Do Not Disturb bypass permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission
@@ -18,6 +19,12 @@
     <uses-feature
         android:name="android.hardware.camera"
         android:required="true" />
+
+    <queries>
+        <intent>
+            <action android:name="android.settings.NOTIFICATION_POLICY_ACCESS_SETTINGS" />
+        </intent>
+    </queries>
 
     <application
         android:name=".app.QRAlarmApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,6 @@
         android:name="android.hardware.camera"
         android:required="true" />
 
-    <queries>
-        <intent>
-            <action android:name="android.settings.NOTIFICATION_POLICY_ACCESS_SETTINGS" />
-        </intent>
-    </queries>
-
     <application
         android:name=".app.QRAlarmApplication"
         android:allowBackup="false"

--- a/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmManager.kt
+++ b/app/src/main/java/com/sweak/qralarm/alarm/QRAlarmManager.kt
@@ -187,6 +187,20 @@ class QRAlarmManager(
         }
     }
 
+    fun canBypassDoNotDisturb(): Boolean =
+        notificationManager.isNotificationPolicyAccessGranted
+
+    fun enableAlarmNotificationChannelDndBypass() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && canBypassDoNotDisturb()) {
+            notificationManager.getNotificationChannel(ALARM_NOTIFICATION_CHANNEL_ID)?.let {
+                if (!it.canBypassDnd()) {
+                    it.setBypassDnd(true)
+                    notificationManager.createNotificationChannel(it)
+                }
+            }
+        }
+    }
+
     override fun notifyAboutMissedAlarm() {
         val alarmMissedPendingIntent = PendingIntent.getActivity(
             context,

--- a/app/src/main/java/com/sweak/qralarm/app/QRAlarmApplication.kt
+++ b/app/src/main/java/com/sweak/qralarm/app/QRAlarmApplication.kt
@@ -38,6 +38,7 @@ class QRAlarmApplication : Application() {
             ).apply {
                 enableLights(true)
                 setSound(null, null)
+                setBypassDnd(notificationManager.isNotificationPolicyAccessGranted)
                 description = getString(R.string.alarm_notification_channel_description)
                 lightColor = Jacarta.toArgb()
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
@@ -273,7 +273,7 @@ private fun PermissionsPageContent(
                 PermissionCard(
                     icon = QRAlarmIcons.Sound,
                     iconContentDescription = stringResource(
-                        R.string.bypass_do_not_disturb
+                        R.string.content_description_sound_icon
                     ),
                     title = stringResource(R.string.bypass_do_not_disturb),
                     subtitle = stringResource(R.string.bypass_do_not_disturb_usage),

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
@@ -133,6 +133,23 @@ fun PermissionsPage(
                     }
                 }
 
+                is PermissionsPageUserEvent.DoNotDisturbPermissionClicked -> {
+                    viewModel.onEvent(event)
+                    try {
+                        context.startActivity(
+                            Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                        )
+                    } catch (_: ActivityNotFoundException) {
+                        Toast.makeText(
+                            context,
+                            resources.getString(
+                                R.string.setting_unavailable_refer_to_the_next_step
+                            ),
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                }
+
                 is PermissionsPageUserEvent.FullScreenIntentPermissionClicked -> {
                     viewModel.onEvent(event)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -252,6 +269,23 @@ private fun PermissionsPageContent(
                 )
             }
 
+            if (state.doNotDisturbPermissionVisible) {
+                PermissionCard(
+                    icon = QRAlarmIcons.Sound,
+                    iconContentDescription = stringResource(
+                        R.string.bypass_do_not_disturb
+                    ),
+                    title = stringResource(R.string.bypass_do_not_disturb),
+                    subtitle = stringResource(R.string.bypass_do_not_disturb_usage),
+                    isGranted = state.doNotDisturbPermissionGranted,
+                    isClickable = !state.doNotDisturbPermissionGranted,
+                    onClick = {
+                        onEvent(PermissionsPageUserEvent.DoNotDisturbPermissionClicked)
+                    },
+                    showDivider = true
+                )
+            }
+
             if (state.fullScreenIntentPermissionVisible) {
                 PermissionCard(
                     icon = QRAlarmIcons.FullScreen,
@@ -336,12 +370,15 @@ private fun PermissionsPageContentPreview() {
                 alarmsPermissionGranted = false,
                 notificationsPermissionVisible = true,
                 notificationsPermissionGranted = false,
+                doNotDisturbPermissionVisible = true,
+                doNotDisturbPermissionGranted = false,
                 fullScreenIntentPermissionVisible = true,
                 fullScreenIntentPermissionGranted = false,
                 backgroundWorkPermissionGranted = false,
                 permissionsRequiringInteraction = setOf(
                     PermissionsPagePermissionKey.ALARMS,
                     PermissionsPagePermissionKey.NOTIFICATIONS,
+                    PermissionsPagePermissionKey.DO_NOT_DISTURB,
                     PermissionsPagePermissionKey.FULL_SCREEN_INTENT,
                     PermissionsPagePermissionKey.BACKGROUND_WORK
                 ),

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
@@ -359,9 +359,9 @@ private fun PermissionsPageContentPreview() {
                 alarmsPermissionGranted = false,
                 notificationsPermissionVisible = true,
                 notificationsPermissionGranted = false,
+                doNotDisturbPermissionVisible = true,
                 doNotDisturbPermissionGranted = false,
                 fullScreenIntentPermissionVisible = true,
-                fullScreenIntentPermissionGranted = false,
                 backgroundWorkPermissionGranted = false,
                 permissionsRequiringInteraction = setOf(
                     PermissionsPagePermissionKey.ALARMS,

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
@@ -258,20 +258,22 @@ private fun PermissionsPageContent(
                 )
             }
 
-            PermissionCard(
-                icon = QRAlarmIcons.Sound,
-                iconContentDescription = stringResource(
-                    R.string.content_description_sound_icon
-                ),
-                title = stringResource(R.string.bypass_do_not_disturb),
-                subtitle = stringResource(R.string.bypass_do_not_disturb_usage),
-                isGranted = state.doNotDisturbPermissionGranted,
-                isClickable = !state.doNotDisturbPermissionGranted,
-                onClick = {
-                    onEvent(PermissionsPageUserEvent.DoNotDisturbPermissionClicked)
-                },
-                showDivider = true
-            )
+            if (state.doNotDisturbPermissionVisible) {
+                PermissionCard(
+                    icon = QRAlarmIcons.Sound,
+                    iconContentDescription = stringResource(
+                        R.string.content_description_sound_icon
+                    ),
+                    title = stringResource(R.string.bypass_do_not_disturb),
+                    subtitle = stringResource(R.string.bypass_do_not_disturb_usage),
+                    isGranted = state.doNotDisturbPermissionGranted,
+                    isClickable = !state.doNotDisturbPermissionGranted,
+                    onClick = {
+                        onEvent(PermissionsPageUserEvent.DoNotDisturbPermissionClicked)
+                    },
+                    showDivider = true
+                )
+            }
 
             if (state.fullScreenIntentPermissionVisible) {
                 PermissionCard(

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPage.kt
@@ -3,6 +3,7 @@ package com.sweak.qralarm.features.onboarding.permissions
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.provider.Settings
@@ -135,19 +136,12 @@ fun PermissionsPage(
 
                 is PermissionsPageUserEvent.DoNotDisturbPermissionClicked -> {
                     viewModel.onEvent(event)
-                    try {
-                        context.startActivity(
-                            Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                    context.startActivityOrShowUnavailableMessage(
+                        intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS),
+                        unavailableMessage = resources.getString(
+                            R.string.setting_unavailable_refer_to_the_next_step
                         )
-                    } catch (_: ActivityNotFoundException) {
-                        Toast.makeText(
-                            context,
-                            resources.getString(
-                                R.string.setting_unavailable_refer_to_the_next_step
-                            ),
-                            Toast.LENGTH_LONG
-                        ).show()
-                    }
+                    )
                 }
 
                 is PermissionsPageUserEvent.FullScreenIntentPermissionClicked -> {
@@ -164,21 +158,16 @@ fun PermissionsPage(
 
                 is PermissionsPageUserEvent.BackgroundWorkPermissionClicked -> {
                     viewModel.onEvent(event)
-                    try {
-                        context.startActivity(
-                            Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-                                data = "package:${context.packageName}".toUri()
-                            }
+                    context.startActivityOrShowUnavailableMessage(
+                        intent = Intent(
+                            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+                        ).apply {
+                            data = "package:${context.packageName}".toUri()
+                        },
+                        unavailableMessage = resources.getString(
+                            R.string.setting_unavailable_refer_to_the_next_step
                         )
-                    } catch (_: ActivityNotFoundException) {
-                        Toast.makeText(
-                            context,
-                            resources.getString(
-                                R.string.setting_unavailable_refer_to_the_next_step
-                            ),
-                            Toast.LENGTH_LONG
-                        ).show()
-                    }
+                    )
                 }
 
                 is PermissionsPageUserEvent.GoToApplicationSettingsClicked -> {
@@ -269,22 +258,20 @@ private fun PermissionsPageContent(
                 )
             }
 
-            if (state.doNotDisturbPermissionVisible) {
-                PermissionCard(
-                    icon = QRAlarmIcons.Sound,
-                    iconContentDescription = stringResource(
-                        R.string.content_description_sound_icon
-                    ),
-                    title = stringResource(R.string.bypass_do_not_disturb),
-                    subtitle = stringResource(R.string.bypass_do_not_disturb_usage),
-                    isGranted = state.doNotDisturbPermissionGranted,
-                    isClickable = !state.doNotDisturbPermissionGranted,
-                    onClick = {
-                        onEvent(PermissionsPageUserEvent.DoNotDisturbPermissionClicked)
-                    },
-                    showDivider = true
-                )
-            }
+            PermissionCard(
+                icon = QRAlarmIcons.Sound,
+                iconContentDescription = stringResource(
+                    R.string.content_description_sound_icon
+                ),
+                title = stringResource(R.string.bypass_do_not_disturb),
+                subtitle = stringResource(R.string.bypass_do_not_disturb_usage),
+                isGranted = state.doNotDisturbPermissionGranted,
+                isClickable = !state.doNotDisturbPermissionGranted,
+                onClick = {
+                    onEvent(PermissionsPageUserEvent.DoNotDisturbPermissionClicked)
+                },
+                showDivider = true
+            )
 
             if (state.fullScreenIntentPermissionVisible) {
                 PermissionCard(
@@ -370,7 +357,6 @@ private fun PermissionsPageContentPreview() {
                 alarmsPermissionGranted = false,
                 notificationsPermissionVisible = true,
                 notificationsPermissionGranted = false,
-                doNotDisturbPermissionVisible = true,
                 doNotDisturbPermissionGranted = false,
                 fullScreenIntentPermissionVisible = true,
                 fullScreenIntentPermissionGranted = false,
@@ -387,5 +373,16 @@ private fun PermissionsPageContentPreview() {
             ),
             onEvent = {}
         )
+    }
+}
+
+private fun Context.startActivityOrShowUnavailableMessage(
+    intent: Intent,
+    unavailableMessage: String
+) {
+    try {
+        startActivity(intent)
+    } catch (_: ActivityNotFoundException) {
+        Toast.makeText(this, unavailableMessage, Toast.LENGTH_LONG).show()
     }
 }

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageState.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageState.kt
@@ -8,6 +8,8 @@ data class PermissionsPageState(
     val alarmsPermissionGranted: Boolean = true,
     val notificationsPermissionVisible: Boolean = false,
     val notificationsPermissionGranted: Boolean = true,
+    val doNotDisturbPermissionVisible: Boolean = false,
+    val doNotDisturbPermissionGranted: Boolean = true,
     val fullScreenIntentPermissionVisible: Boolean = false,
     val fullScreenIntentPermissionGranted: Boolean = true,
     val backgroundWorkPermissionGranted: Boolean = false,

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageState.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageState.kt
@@ -8,7 +8,6 @@ data class PermissionsPageState(
     val alarmsPermissionGranted: Boolean = true,
     val notificationsPermissionVisible: Boolean = false,
     val notificationsPermissionGranted: Boolean = true,
-    val doNotDisturbPermissionVisible: Boolean = false,
     val doNotDisturbPermissionGranted: Boolean = true,
     val fullScreenIntentPermissionVisible: Boolean = false,
     val fullScreenIntentPermissionGranted: Boolean = true,

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageState.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageState.kt
@@ -8,6 +8,7 @@ data class PermissionsPageState(
     val alarmsPermissionGranted: Boolean = true,
     val notificationsPermissionVisible: Boolean = false,
     val notificationsPermissionGranted: Boolean = true,
+    val doNotDisturbPermissionVisible: Boolean = false,
     val doNotDisturbPermissionGranted: Boolean = true,
     val fullScreenIntentPermissionVisible: Boolean = false,
     val fullScreenIntentPermissionGranted: Boolean = true,

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageUserEvent.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsPageUserEvent.kt
@@ -4,6 +4,7 @@ sealed class PermissionsPageUserEvent {
     data object CameraPermissionClicked : PermissionsPageUserEvent()
     data object AlarmsPermissionClicked : PermissionsPageUserEvent()
     data object NotificationsPermissionClicked : PermissionsPageUserEvent()
+    data object DoNotDisturbPermissionClicked : PermissionsPageUserEvent()
     data object FullScreenIntentPermissionClicked : PermissionsPageUserEvent()
     data object BackgroundWorkPermissionClicked : PermissionsPageUserEvent()
     data object GoToApplicationSettingsClicked : PermissionsPageUserEvent()

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
@@ -1,13 +1,17 @@
 package com.sweak.qralarm.features.onboarding.permissions
 
+import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.os.PowerManager
+import android.provider.Settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sweak.qralarm.alarm.QRAlarmManager
 import com.sweak.qralarm.core.domain.user.UserDataRepository
 import com.sweak.qralarm.features.onboarding.permissions.util.PermissionsPagePermissionKey
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,6 +23,7 @@ import javax.inject.Named
 
 @HiltViewModel
 class PermissionsViewModel @Inject constructor(
+    @param:ApplicationContext private val context: Context,
     private val qrAlarmManager: QRAlarmManager,
     private val powerManager: PowerManager,
     @param:Named("PackageName") private val packageName: String,
@@ -35,14 +40,18 @@ class PermissionsViewModel @Inject constructor(
         val alarmsVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                 Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2
         val notificationsVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        val doNotDisturbVisible = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+            .resolveActivity(context.packageManager) != null
         val fullScreenVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 
         _state.update { current ->
             current.copy(
                 alarmsPermissionVisible = alarmsVisible,
                 notificationsPermissionVisible = notificationsVisible,
+                doNotDisturbPermissionVisible = doNotDisturbVisible,
                 fullScreenIntentPermissionVisible = fullScreenVisible,
-                notificationsPermissionGranted = !notificationsVisible
+                notificationsPermissionGranted = !notificationsVisible,
+                doNotDisturbPermissionGranted = !doNotDisturbVisible
             )
         }
 
@@ -61,6 +70,16 @@ class PermissionsViewModel @Inject constructor(
                 } else {
                     true
                 },
+                doNotDisturbPermissionGranted =
+                    if (current.doNotDisturbPermissionVisible) {
+                        qrAlarmManager.canBypassDoNotDisturb().also { isGranted ->
+                            if (isGranted) {
+                                qrAlarmManager.enableAlarmNotificationChannelDndBypass()
+                            }
+                        }
+                    } else {
+                        true
+                    },
                 fullScreenIntentPermissionGranted = if (current.fullScreenIntentPermissionVisible) {
                     qrAlarmManager.canUseFullScreenIntent()
                 } else {
@@ -95,6 +114,9 @@ class PermissionsViewModel @Inject constructor(
 
             is PermissionsPageUserEvent.NotificationsPermissionClicked ->
                 addInteraction(PermissionsPagePermissionKey.NOTIFICATIONS)
+
+            is PermissionsPageUserEvent.DoNotDisturbPermissionClicked ->
+                addInteraction(PermissionsPagePermissionKey.DO_NOT_DISTURB)
 
             is PermissionsPageUserEvent.FullScreenIntentPermissionClicked ->
                 addInteraction(PermissionsPagePermissionKey.FULL_SCREEN_INTENT)
@@ -161,6 +183,12 @@ class PermissionsViewModel @Inject constructor(
 
                 if (current.notificationsPermissionVisible && !notificationsEffective) {
                     add(PermissionsPagePermissionKey.NOTIFICATIONS)
+                }
+
+                if (current.doNotDisturbPermissionVisible &&
+                    !current.doNotDisturbPermissionGranted
+                ) {
+                    add(PermissionsPagePermissionKey.DO_NOT_DISTURB)
                 }
 
                 if (current.fullScreenIntentPermissionVisible &&

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
@@ -35,12 +35,14 @@ class PermissionsViewModel @Inject constructor(
         val alarmsVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                 Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2
         val notificationsVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        val doNotDisturbVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
         val fullScreenVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 
         _state.update { current ->
             current.copy(
                 alarmsPermissionVisible = alarmsVisible,
                 notificationsPermissionVisible = notificationsVisible,
+                doNotDisturbPermissionVisible = doNotDisturbVisible,
                 fullScreenIntentPermissionVisible = fullScreenVisible,
                 notificationsPermissionGranted = !notificationsVisible
             )
@@ -54,9 +56,14 @@ class PermissionsViewModel @Inject constructor(
     }
 
     private fun refreshSystemPermissionsOnly() {
-        val doNotDisturbPermissionGranted = qrAlarmManager.canBypassDoNotDisturb()
+        val doNotDisturbPermissionVisible = _state.value.doNotDisturbPermissionVisible
+        val doNotDisturbPermissionGranted = if (doNotDisturbPermissionVisible) {
+            qrAlarmManager.canBypassDoNotDisturb()
+        } else {
+            true
+        }
 
-        if (doNotDisturbPermissionGranted) {
+        if (doNotDisturbPermissionVisible && doNotDisturbPermissionGranted) {
             qrAlarmManager.enableAlarmNotificationChannelDndBypass()
         }
 
@@ -173,7 +180,9 @@ class PermissionsViewModel @Inject constructor(
                     add(PermissionsPagePermissionKey.NOTIFICATIONS)
                 }
 
-                if (!current.doNotDisturbPermissionGranted) {
+                if (current.doNotDisturbPermissionVisible &&
+                    !current.doNotDisturbPermissionGranted
+                ) {
                     add(PermissionsPagePermissionKey.DO_NOT_DISTURB)
                 }
 

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
@@ -1,17 +1,13 @@
 package com.sweak.qralarm.features.onboarding.permissions
 
-import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.os.PowerManager
-import android.provider.Settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sweak.qralarm.alarm.QRAlarmManager
 import com.sweak.qralarm.core.domain.user.UserDataRepository
 import com.sweak.qralarm.features.onboarding.permissions.util.PermissionsPagePermissionKey
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,7 +19,6 @@ import javax.inject.Named
 
 @HiltViewModel
 class PermissionsViewModel @Inject constructor(
-    @param:ApplicationContext private val context: Context,
     private val qrAlarmManager: QRAlarmManager,
     private val powerManager: PowerManager,
     @param:Named("PackageName") private val packageName: String,
@@ -40,18 +35,14 @@ class PermissionsViewModel @Inject constructor(
         val alarmsVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                 Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2
         val notificationsVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-        val doNotDisturbVisible = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
-            .resolveActivity(context.packageManager) != null
         val fullScreenVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 
         _state.update { current ->
             current.copy(
                 alarmsPermissionVisible = alarmsVisible,
                 notificationsPermissionVisible = notificationsVisible,
-                doNotDisturbPermissionVisible = doNotDisturbVisible,
                 fullScreenIntentPermissionVisible = fullScreenVisible,
-                notificationsPermissionGranted = !notificationsVisible,
-                doNotDisturbPermissionGranted = !doNotDisturbVisible
+                notificationsPermissionGranted = !notificationsVisible
             )
         }
 
@@ -63,12 +54,7 @@ class PermissionsViewModel @Inject constructor(
     }
 
     private fun refreshSystemPermissionsOnly() {
-        val doNotDisturbPermissionGranted =
-            if (_state.value.doNotDisturbPermissionVisible) {
-                qrAlarmManager.canBypassDoNotDisturb()
-            } else {
-                true
-            }
+        val doNotDisturbPermissionGranted = qrAlarmManager.canBypassDoNotDisturb()
 
         if (doNotDisturbPermissionGranted) {
             qrAlarmManager.enableAlarmNotificationChannelDndBypass()
@@ -187,9 +173,7 @@ class PermissionsViewModel @Inject constructor(
                     add(PermissionsPagePermissionKey.NOTIFICATIONS)
                 }
 
-                if (current.doNotDisturbPermissionVisible &&
-                    !current.doNotDisturbPermissionGranted
-                ) {
+                if (!current.doNotDisturbPermissionGranted) {
                     add(PermissionsPagePermissionKey.DO_NOT_DISTURB)
                 }
 

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/PermissionsViewModel.kt
@@ -63,6 +63,17 @@ class PermissionsViewModel @Inject constructor(
     }
 
     private fun refreshSystemPermissionsOnly() {
+        val doNotDisturbPermissionGranted =
+            if (_state.value.doNotDisturbPermissionVisible) {
+                qrAlarmManager.canBypassDoNotDisturb()
+            } else {
+                true
+            }
+
+        if (doNotDisturbPermissionGranted) {
+            qrAlarmManager.enableAlarmNotificationChannelDndBypass()
+        }
+
         _state.update { current ->
             current.copy(
                 alarmsPermissionGranted = if (current.alarmsPermissionVisible) {
@@ -70,16 +81,7 @@ class PermissionsViewModel @Inject constructor(
                 } else {
                     true
                 },
-                doNotDisturbPermissionGranted =
-                    if (current.doNotDisturbPermissionVisible) {
-                        qrAlarmManager.canBypassDoNotDisturb().also { isGranted ->
-                            if (isGranted) {
-                                qrAlarmManager.enableAlarmNotificationChannelDndBypass()
-                            }
-                        }
-                    } else {
-                        true
-                    },
+                doNotDisturbPermissionGranted = doNotDisturbPermissionGranted,
                 fullScreenIntentPermissionGranted = if (current.fullScreenIntentPermissionVisible) {
                     qrAlarmManager.canUseFullScreenIntent()
                 } else {

--- a/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/util/PermissionsPagePermissionKey.kt
+++ b/app/src/main/java/com/sweak/qralarm/features/onboarding/permissions/util/PermissionsPagePermissionKey.kt
@@ -1,5 +1,5 @@
 package com.sweak.qralarm.features.onboarding.permissions.util
 
 enum class PermissionsPagePermissionKey {
-    CAMERA, ALARMS, NOTIFICATIONS, FULL_SCREEN_INTENT, BACKGROUND_WORK
+    CAMERA, ALARMS, NOTIFICATIONS, DO_NOT_DISTURB, FULL_SCREEN_INTENT, BACKGROUND_WORK
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@
     <string name="alarms_usage">Used for scheduling alarms at precise time.</string>
     <string name="notifications">Notifications</string>
     <string name="notifications_usage">Used to accompany the alarm with a visible notification.</string>
+    <string name="bypass_do_not_disturb">Bypass Do Not Disturb</string>
+    <string name="bypass_do_not_disturb_usage">Allows alarms to alert you while Do Not Disturb is enabled.</string>
     <string name="full_screen_display">Full screen display</string>
     <string name="full_screen_display_usage">Used for displaying full screen alarm notification.</string>
     <string name="notifications_permission_required">Notifications permission required</string>


### PR DESCRIPTION
Adds a permission option that lets QRAlarm bypass Do Not Disturb so alarms can alert while DND is enabled.

Tested on an Android 16 emulator.